### PR TITLE
Upgrade to ra hasura adaptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "apollo-client": "^2.6.10",
-    "ra-data-hasura-graphql": "^0.1.10",
+    "ra-data-hasura": "^0.2.0",
     "react": "^16.13.1",
     "react-admin": "^3.6.0",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "3.4.1"
   },
   "scripts": {
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
+    "@types/react-router-dom": "^5.3.2",
     "typescript": "^3.9.5"
   }
 }

--- a/src/get-app.tsx
+++ b/src/get-app.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import App from './App'
-import buildHasuraProvider from 'ra-data-hasura-graphql';
+import buildHasuraProvider from 'ra-data-hasura';
 
 const uri = "https://react-admin-low-code.hasura.app/v1/graphql";
 
 export default async function getApp() {
-  const provider = await buildHasuraProvider({ clientOptions: { uri: uri }})
-  return () => (
+  const provider = await buildHasuraProvider({
+    clientOptions: { uri: uri }
+  });  return () => (
     <App dataProvider={provider} />
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,11 +3,12 @@ import './index.css';
 import getApp from './get-app'
 import * as serviceWorker from './service-worker';
 import ReactDOM from 'react-dom'
+import { BrowserRouter } from 'react-router-dom';
 
 getApp().then((App: React.FC) =>
   ReactDOM.render(
     <React.StrictMode>
-      <App />
+        <BrowserRouter><App/></BrowserRouter>
     </React.StrictMode>,
     document.getElementById('root')
   )

--- a/src/ra-data-hasura.d.ts
+++ b/src/ra-data-hasura.d.ts
@@ -1,0 +1,1 @@
+declare module "ra-data-hasura"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "isolatedModules": true
   },
   "include": [
-    "src"
+    "src", "src/ra-data-hasura.d.ts"
   ]
 }


### PR DESCRIPTION
Description:

This PR upgrade the `ra-data-hasura` from legacy adaptor.

When you run the app you will see the error `field \"users_aggregate\" not found in type: 'query_root`

We need to allow the permission for this field in hasura service: 
Reference: https://github.com/hasura/graphql-engine/issues/3108


Note: Used `react-router-dom` to fix a routing error.